### PR TITLE
Update Sinatra to patch security vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,4 @@ group :development do
   gem 'stringex', '~> 1.4.0'
 end
 
-gem 'sinatra', '~> 1.4.2'
+gem 'sinatra', '~> 1.4.8'


### PR DESCRIPTION
CVE-2012-6684 - TEXTILE LINK PARSING XSS
RedCloth Gem for Ruby contains a flaw that allows a cross-site scripting (XSS) attack. This flaw exists because the program does not validate input when parsing textile links before returning it to users. This may allow a remote attacker to create a specially crafted request that would execute arbitrary script code in a user's browser session within the trust relationship between their browser and the server.

Affected versions: All versions
Fixed versions: 4.3.0
Identifier: CVE-2012-6684
Solution: Upgrade to latest version.
Credit: Kousuke Ebihara, Antonio Terceiro
Sources: https://github.com/jgarber/redcloth/commit/2f6dab4d6aea5cee778d2f37a135637fe3f1573c 
https://bugs.debian.org/774748 
http://co3k.org/blog/redcloth-unfixed-xss-en